### PR TITLE
Fix conversion of zip-directory entries

### DIFF
--- a/zip.lisp
+++ b/zip.lisp
@@ -51,7 +51,7 @@
 
 (flet ((convert-entries (file)
          (loop for entry across (zippy:entries file)
-               do (if (find :directory (zippy:attributes entry))
+               do (if (getf (first (zippy:attributes entry)) :directory)
                       (change-class entry 'zip-directory)
                       (change-class entry 'zip-file)))
          file))


### PR DESCRIPTION
The first return value of ZIPPY:ATTRIBUTES is a plist.